### PR TITLE
fix(assets): restore the recipes lost to missing separators

### DIFF
--- a/assets/prefabs/CookingRecipes.prefab
+++ b/assets/prefabs/CookingRecipes.prefab
@@ -247,13 +247,13 @@
           "Cooking:Coconut": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:BoiledEgg": {
         "inputs": {
           "Cooking:Egg": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:CookedBean": {
         "inputs": {
           "Cooking:bean": 1,
@@ -262,37 +262,37 @@
           "Cooking:salt": 1
         },
         "outputCount": 1
-      }
+      },
       "CookedBrownRice": {
         "inputs": {
           "Cooking:BrownRice": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:CookedCorn": {
         "inputs": {
           "Cooking:maize": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:CookedKale": {
         "inputs": {
           "Cooking:kale": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:CookedRice": {
         "inputs": {
           "Cooking:whiteRice": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:CookedTurnip": {
         "inputs": {
           "PlantPack:turnip": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:Croutons": {
         "inputs": {
           "Cooking:bread": 1,
@@ -300,7 +300,7 @@
           "Cooking:butter": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:PeachPie": {
         "inputs": {
           "Cooking:flour": 1,
@@ -308,7 +308,7 @@
           "Cooking:Peach": 5
         },
         "outputCount": 1
-      }
+      },
       "Cooking:PumpkinSoup": {
         "inputs": {
           "Cooking:pumpkin": 3,
@@ -316,14 +316,14 @@
           "Cooking:onion": 1
         },
         "outputCount": 1
-      }
+      },
       "Cooking:RoastPotatoes": {
         "inputs": {
           "Cooking:butter": 1,
           "Cooking:potato": 3
         },
         "outputCount": 1
-      }
+      },
       "Cooking:SauteedApples": {
         "inputs": {
           "Cooking:flour": 1,


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

- `CookingRecipes.prefab` was missing the comma between eleven recipe entries — `}` running straight into the next key. No JSON parser accepts that, lenient or strict, so the prefab fails to parse as a whole and **every** recipe it defines is unavailable in game, not only the ones after the first break.
- Found by the build-time JSON asset validation proposed in MovingBlocks/Terasology#5326, on its first run against real module content.

## Test plan

- [x] `./gradlew :modules:Cooking:validateJsonAssets` fails on `develop` and passes with this change.
- [x] Parses cleanly under the engine's own lenient Gson configuration, which is what actually loads the file.
